### PR TITLE
3 minor issues fixed

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -98,12 +98,16 @@ def get_md5_digest(path):
 def build_coffee(path):
 	debug('Compiling %s' % path)
 	command_args = ['coffee', '-b', '-c', path]
-	process = subprocess.Popen(command_args, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+	process = subprocess.Popen(command_args, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
 	result = process.wait()
 	if result != 0:
 		msg = process.stderr.read()
 		if msg:
-			err("%s (%s)" % (msg, path))
+			if msg.find("\n"):
+				msg1 = msg[:msg.find("\n")]
+			else:
+				msg1 = msg
+			err("%s (%s)" % (msg1, path))
 		else:
 			err("CoffeeScript compiler call for %s failed but no error message was generated" % path)
 		return False
@@ -124,6 +128,9 @@ def build_all_coffee(path, file_hash_folder):
 							file_hashes[file_path] != digest):
 					if build_coffee(file_path):
 						file_hashes[file_path] = digest
+					else:
+						file_hashes[file_path] = None
+						os.remove("%s.js" % file_path[:-7])
 	write_file_hashes(file_hash_folder, file_hashes)
 
 

--- a/plugin.py
+++ b/plugin.py
@@ -130,7 +130,8 @@ def build_all_coffee(path, file_hash_folder):
 						file_hashes[file_path] = digest
 					else:
 						file_hashes[file_path] = None
-						os.remove("%s.js" % file_path[:-7])
+						if os.path.exists("%s.js" % file_path[:-7]):
+							os.remove("%s.js" % file_path[:-7])
 	write_file_hashes(file_hash_folder, file_hashes)
 
 


### PR DESCRIPTION
- subprocess is now grabbing properly stderr (was not working in python2.7)
- only the first line of the error message by coffeescript is logged (the rest was nodejs trace)
- when a coffee file does not compile, hash is now voided properly & resulting .js deleted to avoid stale copies of the generated js to pollute

Also, please see following patch to compiler.py, that solves the problem of having .coffee files copied to the resulting app: https://github.com/arnaudsj/titanium_mobile/commit/e78766e6327665c9f2214894b7e2acb21648d951
